### PR TITLE
Added intensity calculation to getfreq.py and fixed mass division for intensity.py

### DIFF
--- a/castor/classes/class_dipol.py
+++ b/castor/classes/class_dipol.py
@@ -24,26 +24,26 @@ from dipols.subclass_frequency import Frequency
 class Dipols:
     """Holds the dipols from calculating the Hessian"""
     def __init__(self):
-        self.decimals = 6
-        self.spaces = 3
-        self.matrix = None
+        self.decimals  = 6
+        self.spaces    = 3
+        self.matrix    = None
         self.finitdiff = None
-        self.elnr        = np.dtype(int)    # Vector of element numbers.
-        self.elements    = []               # List of element names.
-        self.masses      = []               # List of element masses.
+        self.elnr      = np.dtype(int)    # Vector of element numbers.
+        self.elements  = []               # List of element names.
+        self.masses    = []               # List of element masses.
     def read(self, outcar_in):
         readmode = 0
         with open(outcar_in, 'r') as inputfile:
-            self.nions = None
-            self.dipol_diff = []
-            self.frequencies = []
+            self.nions           = None
+            self.dipol_diff      = []
+            self.frequencies     = []
             self.degrees_freedom = []
-            vaspversion=None
-            nwrite      = None   # Which nwrite has been used.
-            dipol_correction=None
-            self.dipol_store=None
-            self.dipol_ref=None
-            scale_diff                 = False  # Whether displacements should be corrected for mass.
+            vaspversion          = None
+            nwrite               = None   # Which nwrite has been used.
+            dipol_correction     = None
+            self.dipol_store     = None
+            self.dipol_ref       = None
+            scale_diff           = False  # Whether displacements should be corrected for mass.
             for line in inputfile:
                 if(readmode == 0):
                     #which version of vasp has been used?
@@ -78,7 +78,7 @@ class Dipols:
                     # Which NWRITE is used?
                     match = re.search('^[ \t]*NWRITE[ \t]*=[ \t]*([0-4])[ \t]+.*$',line)
                     if(match):
-                        nwrite = int(match.group(1))
+                        nwrite   = int(match.group(1))
                         readmode += 1
                         continue
                 elif(readmode == 2):
@@ -114,7 +114,7 @@ class Dipols:
                         # "------------------------ aborting loop because EDIFF is reached ----------------------------------------"
                         if(match): # electronic convergence
                             if(self.dipol_ref==None):
-                                self.dipol_ref = self.dipol_store
+                                self.dipol_ref   = self.dipol_store
                                 self.dipol_store = None
                             else:
                                 self.dipol_diff.append(self.dipol_store)
@@ -134,7 +134,7 @@ class Dipols:
                         readmode += 1
                         if(vaspversion == 5 and nwrite < 3):
                             scale_diff = True
-                            readmode += 1
+                            readmode   += 1
                         continue
                 elif(readmode == 6):
                     match = re.search('^[ \t]*[0-9]+ f  =[ \t]*([0-9.]+) THz[ \t]*([0-9.]+) 2PiTHz[ \t]*([0-9.]+) cm-1[ \t]*([0-9.]+) meV[ \t]*$',line)
@@ -154,7 +154,7 @@ class Dipols:
                             atnum += 1
                             diff = [float(match.group(4)), float(match.group(5)), float(match.group(6))]
                             if(scale_diff == True):
-                                mass = self.getMass(atnum)
+                                mass    = self.getMass(atnum)
                                 diff[0] /= math.sqrt(mass)
                                 diff[1] /= math.sqrt(mass)
                                 diff[2] /= math.sqrt(mass)
@@ -195,14 +195,14 @@ class Dipols:
         self.matrix.setIntensities(self.frequencies)
     def writeList3(self, list3, decimals_in = 6, spaces_in = 3):
         self.decimals = decimals_in
-        self.spaces = spaces_in
-        string = ""
-        xcor = '{0:.{width}f}'.format(list3[0], width=self.decimals)
-        ycor = '{0:.{width}f}'.format(list3[1], width=self.decimals)
-        zcor = '{0:.{width}f}'.format(list3[2], width=self.decimals)
-        string += '{0:>{width}}'.format(xcor, width=self.decimals+self.spaces+4)
-        string += '{0:>{width}}'.format(ycor, width=self.decimals+self.spaces+4)
-        string += '{0:>{width}}'.format(zcor, width=self.decimals+self.spaces+4)
+        self.spaces   = spaces_in
+        string        = ""
+        xcor          = '{0:.{width}f}'.format(list3[0], width=self.decimals)
+        ycor          = '{0:.{width}f}'.format(list3[1], width=self.decimals)
+        zcor          = '{0:.{width}f}'.format(list3[2], width=self.decimals)
+        string        += '{0:>{width}}'.format(xcor, width=self.decimals+self.spaces+4)
+        string        += '{0:>{width}}'.format(ycor, width=self.decimals+self.spaces+4)
+        string        += '{0:>{width}}'.format(zcor, width=self.decimals+self.spaces+4)
         return string
     def write(self,printmode = "all"):
         if(printmode=="all"):

--- a/castor/classes/class_dipol.py
+++ b/castor/classes/class_dipol.py
@@ -28,6 +28,9 @@ class Dipols:
         self.spaces = 3
         self.matrix = None
         self.finitdiff = None
+        self.elnr        = np.dtype(int)    # Vector of element numbers.
+        self.elements    = []               # List of element names.
+        self.masses      = []               # List of element masses.
     def read(self, outcar_in):
         readmode = 0
         with open(outcar_in, 'r') as inputfile:
@@ -36,9 +39,11 @@ class Dipols:
             self.frequencies = []
             self.degrees_freedom = []
             vaspversion=None
+            nwrite      = None   # Which nwrite has been used.
             dipol_correction=None
             self.dipol_store=None
             self.dipol_ref=None
+            scale_diff                 = False  # Whether displacements should be corrected for mass.
             for line in inputfile:
                 if(readmode == 0):
                     #which version of vasp has been used?
@@ -50,7 +55,33 @@ class Dipols:
                             sys.exit()
                         readmode += 1
                         continue
-                elif(readmode == 1):
+                elif(readmode == 1): # Search for elemental properties
+                    # Which element name?
+                    match = re.search('^[ \t]*TITEL[ \t]+=[ \t]+[A-Z_]+ ([A-Za-z]+) [0-9A-Za-z]+[ \t]*$',line)
+                    if(match):
+                        self.elements.append(match.group(1))
+                        continue
+                    # What element mass?
+                    match = re.search('^[ \t]*POMASS[ \t]+=[ \t]+([0-9.]+);.*$',line)
+                    if(match):
+                        self.masses.append(float(match.group(1)))
+                        continue
+                    # How many atoms per type of element?
+                    match = re.search('^[ \t]*ions per type =([0-9 \t]+)[ \t]*$',line)
+                    if(match):
+                        stringlist_values = match.group(1).split()
+                        intlist_values = []
+                        for i in range(0,len(stringlist_values)):
+                            intlist_values.append(int(stringlist_values[i]))
+                        self.elnr = np.array(intlist_values)
+                        continue
+                    # Which NWRITE is used?
+                    match = re.search('^[ \t]*NWRITE[ \t]*=[ \t]*([0-4])[ \t]+.*$',line)
+                    if(match):
+                        nwrite = int(match.group(1))
+                        readmode += 1
+                        continue
+                elif(readmode == 2):
                     #which LDIPOL tag has been set
                     match = re.search('^[ \t]*LDIPOL[ \t]*=[ \t]*([FT])[ \t]*.*$',line)
                     if(match): # LDIPOL tag found
@@ -63,7 +94,7 @@ class Dipols:
                             sys.exit()
                         readmode += 1
                         continue
-                elif(readmode == 2):
+                elif(readmode == 3):
                     #read dipole moments
                     match = re.search('^[ \t]*dipolmoment[ \t]*([0-9.-]+)[ \t]*([0-9.-]+)[ \t]*([0-9.-]+)[ \t]*electrons.*$',line)
                     # " dipolmoment          -0.000002     -0.051875     -0.352631 electrons x Angstroem"
@@ -97,27 +128,37 @@ class Dipols:
                         self.degrees_freedom = match.group(0).split()
                         readmode += 1
                         continue
-                elif(readmode == 3 or readmode == 4):
+                elif(readmode == 4 or readmode == 5):
                     #make sure we are reading the correct dynamical matrix
                     if(re.search('^[ \t]*Eigenvectors and eigenvalues of the dynamical matrix[ \t]*$',line)):
                         readmode += 1
-                        if(vaspversion == 5):
+                        if(vaspversion == 5 and nwrite < 3):
+                            scale_diff = True
                             readmode += 1
                         continue
-                elif(readmode == 5):
+                elif(readmode == 6):
                     match = re.search('^[ \t]*[0-9]+ f  =[ \t]*([0-9.]+) THz[ \t]*([0-9.]+) 2PiTHz[ \t]*([0-9.]+) cm-1[ \t]*([0-9.]+) meV[ \t]*$',line)
                     # "6 f  =    2.865417 THz    18.003946 2PiTHz   95.580018 cm-1    11.850416 meV"
                     if(match): # real freq found
+                        atnum = 0
                         self.frequencies.append(Frequency(float(match.group(1)), float(match.group(2)), float(match.group(3)), float(match.group(4)),False))
                         continue
                     match = re.search('^[ \t]*[0-9]+ f/i=[ \t]*([0-9.]+) THz[ \t]*([0-9.]+) 2PiTHz[ \t]*([0-9.]+) cm-1[ \t]*([0-9.]+) meV[ \t]*$',line)
                     if(match): # imag freq found
+                        atnum = 0
                         self.frequencies.append(Frequency(float(match.group(1)), float(match.group(2)), float(match.group(3)), float(match.group(4)),True))
                         continue
                     if(len(self.frequencies)>0):
                         match = re.search('^[ \t]*([0-9.-]+)[ \t]*([0-9.-]+)[ \t]*([0-9.-]+)[ \t]*([0-9.-]+)[ \t]*([0-9.-]+)[ \t]*([0-9.-]+)[ \t]*$',line)
                         if(match): # reading atomic displacement line
-                            self.frequencies[-1].atdiff.append([float(match.group(4)), float(match.group(5)), float(match.group(6))])
+                            atnum += 1
+                            diff = [float(match.group(4)), float(match.group(5)), float(match.group(6))]
+                            if(scale_diff == True):
+                                mass = self.getMass(atnum)
+                                diff[0] /= math.sqrt(mass)
+                                diff[1] /= math.sqrt(mass)
+                                diff[2] /= math.sqrt(mass)
+                            self.frequencies[-1].atdiff.append(diff)
                             continue
                         match = re.search('^[ \t]*Finite differences POTIM=[ \t]*([0-9.E-]+)[ \t]*$',line)
                         # "Finite differences POTIM=  2.00000000000000004E-002"
@@ -125,20 +166,29 @@ class Dipols:
                             self.finitdiff = float(match.group(1))
                             readmode += 1 # making sure no more freqs are read
                             continue
-                elif(readmode == 6):
+                elif(readmode == 7):
                     break
 
         if(readmode == 0):
             print "Error: Could not find Vasp version"
         elif(readmode ==1):
-            print "Error: Could not find LDIPOL tag"
+            print "Error: Could not find elemental properties"
         elif(readmode ==2):
+            print "Error: Could not find LDIPOL tag"
+        elif(readmode ==3):
             print "Error: Could not find dipol moments"
-        elif(readmode ==3 or readmode == 4):
+        elif(readmode ==4 or readmode == 5):
             print "Error: Could not find dynamical matrix"
-        elif(readmode ==5):
+        elif(readmode ==6):
             print "Error: Could not find all frequencies"
-
+    def getMass(self, number_in):
+        atomsum = 0
+        for number, mass in zip(self.elnr, self.masses):
+            atomsum += number
+            if(number_in <= atomsum):
+                return mass
+        print "Could not get element mass"
+        sys.exit()
     def getMatrix(self):
         self.matrix = Matrix()
         self.matrix.setup(self.dipol_diff,self.degrees_freedom,self.finitdiff)

--- a/castor/classes/class_dipol.py
+++ b/castor/classes/class_dipol.py
@@ -91,7 +91,7 @@ class Dipols:
                             continue
                 
                     #read the degrees of freedom
-                    "              11X         11Y         11Z         12X         12Y         12Z"
+                    # "              11X         11Y         11Z         12X         12Y         12Z"
                     match = re.search('^([ \t]+[0-9]+[XYZ])+[ \t]*$',line)
                     if(match):
                         self.degrees_freedom = match.group(0).split()

--- a/castor/classes/class_hessian.py
+++ b/castor/classes/class_hessian.py
@@ -103,7 +103,7 @@ class Hessian:
                     match = re.search('^[ \t]*ions per type =([0-9 \t]+)[ \t]*$',line)
                     if(match):
                         stringlist_values = match.group(1).split()
-                        intlist_values = []
+                        intlist_values    = []
                         for i in range(0,len(stringlist_values)):
                             intlist_values.append(int(stringlist_values[i]))
                         self.elnr = np.array(intlist_values)
@@ -111,7 +111,7 @@ class Hessian:
                     # Which NWRITE is used?
                     match = re.search('^[ \t]*NWRITE[ \t]*=[ \t]*([0-4])[ \t]+.*$',line)
                     if(match):
-                        nwrite = int(match.group(1))
+                        nwrite   = int(match.group(1))
                         readmode += 1
                         continue
                 elif(readmode == 2): # Read the DIPOL tags.
@@ -163,7 +163,7 @@ class Hessian:
                             if(match): # electronic convergence
                                 if(self.dipol_ref==None):
                                     self.dipol_ref = dipol_store
-                                    dipol_store = None
+                                    dipol_store    = None
                                 else:
                                     self.dipol_diff.append(dipol_store)
                                     dipol_store = None
@@ -179,7 +179,7 @@ class Hessian:
                     if(match):
                         self.freedom = match.group(0).split()
                         freedom_count = 0
-                        readmode += 1
+                        readmode      += 1
                         continue
                 elif(readmode == 5): # Read not symmetrized hessian matrix.
                     # Filling the matrix
@@ -213,7 +213,7 @@ class Hessian:
                         readmode += 1
                         if(vaspversion == 5 and nwrite < 3):
                             scale_diff = True
-                            readmode += 1
+                            readmode   += 1
                         continue
                 elif(readmode == 8):
                     match = re.search('^[ \t]*[0-9]+ f  =[ \t]*([0-9.]+) THz[ \t]*([0-9.]+) 2PiTHz[ \t]*([0-9.]+) cm-1[ \t]*([0-9.]+) meV[ \t]*$',line)
@@ -233,7 +233,7 @@ class Hessian:
                             atnum += 1
                             diff = [float(match.group(4)), float(match.group(5)), float(match.group(6))]
                             if(scale_diff == True):
-                                mass = self.getMass(atnum)
+                                mass    = self.getMass(atnum)
                                 diff[0] /= math.sqrt(mass)
                                 diff[1] /= math.sqrt(mass)
                                 diff[2] /= math.sqrt(mass)
@@ -269,10 +269,9 @@ class Hessian:
         new.setup(self.matrix.nonsym, self.matrix.sym, None, None)
         self.newmatrices.append(new)
     def mapMass(self, element_in = None, mass_in = None, numbers_in = None):
-        self.element = element_in
-        self.mass = mass_in
-        self.numbers = numbers_in
-
+        self.element   = element_in
+        self.mass      = mass_in
+        self.numbers   = numbers_in
         self.numberset = self.string2numberset(numbers_in, element_in)
         
         self.massmap.clear()
@@ -350,7 +349,7 @@ class Hessian:
         return 0.0005 * zpe
     def calcPartition(self, freqs_in):
         kbT = self.temp * self.kb
-        nu = 1.0
+        nu  = 1.0
         for freq in freqs_in:
             if(freq.imaginary==False):
                 nu *= 1.0 / (1.0 - math.exp(-freq.meV / kbT))
@@ -465,14 +464,14 @@ class Hessian:
             self.getIntens(newmat.frequencies)
     def writeList3(self, list3, decimals_in = 6, spaces_in = 3):
         self.decimals = decimals_in
-        self.spaces = spaces_in
-        string = ""
-        xcor = '{0:.{width}f}'.format(list3[0], width=self.decimals)
-        ycor = '{0:.{width}f}'.format(list3[1], width=self.decimals)
-        zcor = '{0:.{width}f}'.format(list3[2], width=self.decimals)
-        string += '{0:>{width}}'.format(xcor, width=self.decimals+self.spaces+4)
-        string += '{0:>{width}}'.format(ycor, width=self.decimals+self.spaces+4)
-        string += '{0:>{width}}'.format(zcor, width=self.decimals+self.spaces+4)
+        self.spaces   = spaces_in
+        string        = ""
+        xcor          = '{0:.{width}f}'.format(list3[0], width=self.decimals)
+        ycor          = '{0:.{width}f}'.format(list3[1], width=self.decimals)
+        zcor          = '{0:.{width}f}'.format(list3[2], width=self.decimals)
+        string        += '{0:>{width}}'.format(xcor, width=self.decimals+self.spaces+4)
+        string        += '{0:>{width}}'.format(ycor, width=self.decimals+self.spaces+4)
+        string        += '{0:>{width}}'.format(zcor, width=self.decimals+self.spaces+4)
         return string
     def writeDipols(self,printmode = "all"):
         if(printmode=="all"):

--- a/castor/classes/class_hessian.py
+++ b/castor/classes/class_hessian.py
@@ -359,13 +359,24 @@ class Hessian:
             print "---------------------------"
             print "-        Settings:        -"
             print "---------------------------"
-            print "Element to set new mass = " + str(self.element)
-            if(self.numbers == None):
-                print "Atom numbers of element to set new mass = all"
+            if(self.element == None):
+                print "No elements selected to set new mass."
             else:
-                print "Atom numbers of element to set new mass = " + str(self.numbers)
-            print "New mass = " + str(self.mass)
+                print "Element to set new mass = " + str(self.element)
+                if(self.numbers == None):
+                    print "Atom numbers of element to set new mass = all"
+                else:
+                    print "Atom numbers of element to set new mass = " + str(self.numbers)
+                print "New mass = " + str(self.mass)
             print "\n"
+            if(self.idipol > 0):
+                print "---------------------------"
+                print "-   Dipole information:   -"
+                print "---------------------------"
+                print "IDIPOL = " + str(self.idipol)
+                print "Initial dipole moment: " + self.writeList3(self.dipol_ref)
+                self.dipols.printMatrix()
+                print "\n"
             if(self.matrix != None):
                 # print "---------------------------"
                 # print "-  Original nonsym matrix:  -"
@@ -426,6 +437,42 @@ class Hessian:
             nu = self.calcPartition(self.matrix.frequencies)
             print 'Total ZPE contribution of frequencies in eV: {0:.{width}f}'.format(zpe, width=self.decimals)
             print 'Vibrational partition function: {0:.{width}f}'.format(nu, width=self.decimals)
+            if(self.idipol > 0):
+                count    = 0
+                highfreq = None
+                highint  = None
+                for freq in self.matrix.frequencies:
+                    count += 1
+                    if(count == 1):
+                        highfreq = freq
+                        highint  = freq
+                        freqcount = count
+                        intcount = count
+                    else:
+                        if(freq.cm1 > highint.cm1):
+                            highfreq = freq
+                            freqcount = count
+                        if(freq.intensity[3] > highint.intensity[3]):
+                            highint = freq
+                            intcount = count
+                hf_f = highfreq.cm1
+                hf_i = highfreq.intensity[3]
+                hi_f = highint.cm1
+                hi_i = highint.intensity[3]
+                hf_str = '{0:>{width}}'.format(freqcount, width=self.spaces)
+                hf_str += " "
+                if(highfreq.imaginary==False):
+                    hf_str += "f  ="
+                elif(highfreq.imaginary==True):
+                    hf_str += "f/i="
+                hi_str = '{0:>{width}}'.format(intcount, width=self.spaces)
+                hi_str += " "
+                if(highint.imaginary==False):
+                    hi_str += "f  ="
+                elif(highint.imaginary==True):
+                    hi_str += "f/i="
+                print 'Highest frequency: {0} {1:.{width}f} cm-1 | {2:.{width}f} int'.format(hf_str, hf_f,hf_i, width=self.decimals)
+                print 'Highest intensity: {0} {1:.{width}f} cm-1 | {2:.{width}f} int'.format(hi_str, hi_f,hi_i, width=self.decimals)
 
             for newmatrix in self.newmatrices:
                 self.printChanges()
@@ -433,6 +480,42 @@ class Hessian:
                 nu = self.calcPartition(newmatrix.frequencies)
                 print 'Total ZPE contribution of new frequencies in eV: {0:.{width}f}'.format(zpe, width=self.decimals)
                 print 'New vibrational partition function: {0:.{width}f}'.format(nu, width=self.decimals)
+                if(self.idipol > 0):
+                    count    = 0
+                    highfreq = None
+                    highint  = None
+                    for freq in newmatrix.frequencies:
+                        count += 1
+                        if(count == 1):
+                            highfreq = freq
+                            highint  = freq
+                            freqcount = count
+                            intcount = count
+                        else:
+                            if(freq.cm1 > highint.cm1):
+                                highfreq = freq
+                                freqcount = count
+                            if(freq.intensity[3] > highint.intensity[3]):
+                                highint = freq
+                                intcount = count
+                    hf_f = highfreq.cm1
+                    hf_i = highfreq.intensity[3]
+                    hi_f = highint.cm1
+                    hi_i = highint.intensity[3]
+                    hf_str = '{0:>{width}}'.format(freqcount, width=self.spaces)
+                    hf_str += " "
+                    if(highfreq.imaginary==False):
+                        hf_str += "f  ="
+                    elif(highfreq.imaginary==True):
+                        hf_str += "f/i="
+                    hi_str = '{0:>{width}}'.format(intcount, width=self.spaces)
+                    hi_str += " "
+                    if(highint.imaginary==False):
+                        hi_str += "f  ="
+                    elif(highint.imaginary==True):
+                        hi_str += "f/i="
+                    print 'Highest frequency: {0} {1:.{width}f} cm-1 | {2:.{width}f} int'.format(hf_str, hf_f,hf_i, width=self.decimals)
+                    print 'Highest intensity: {0} {1:.{width}f} cm-1 | {2:.{width}f} int'.format(hi_str, hi_f,hi_i, width=self.decimals)
     def printChanges(self):
         if(len(self.numberset)>0):
             for i in self.numberset:

--- a/castor/classes/dipols/subclass_frequency.py
+++ b/castor/classes/dipols/subclass_frequency.py
@@ -20,16 +20,16 @@ import math
 class Frequency:
     """Defines a frequency"""
     def __init__(self, Thz_in = 0, THz2Pi_in = 0, cm1_in = 0, meV_in = 0, imag_in = False):
-        self.THz = Thz_in
-        self.THz2Pi = THz2Pi_in
-        self.cm1 = cm1_in
-        self.meV = meV_in
+        self.THz       = Thz_in
+        self.THz2Pi    = THz2Pi_in
+        self.cm1       = cm1_in
+        self.meV       = meV_in
         self.imaginary = imag_in
-        self.atdiff = [] #filled by class_dipol.py during outcar read
+        self.atdiff    = [] #filled by class_dipol.py during outcar read
         self.intensity = None #set by subclass_matrix.py in setIntensities
     def getString(self, decimals_in = 6, spaces_in = 3, prefix = None, printmode = "all"):
-        self.decimals = decimals_in
-        self.spaces = spaces_in
+        self.decimals  = decimals_in
+        self.spaces    = spaces_in
         string = ""
         if(prefix!=None):
             string += '{0:>{width}}'.format(prefix, width=self.spaces)
@@ -39,33 +39,33 @@ class Frequency:
         elif(self.imaginary==True):
             string += "f/i="
         if(printmode=="all" or printmode=="freq" or self.intensity == None):
-            data = '{0:.{width}f} THz'.format(self.THz, width=self.decimals)
+            data   = '{0:.{width}f} THz'.format(self.THz, width=self.decimals)
             string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
-            data = '{0:.{width}f} 2PiTHz'.format(self.THz2Pi, width=self.decimals)
+            data   = '{0:.{width}f} 2PiTHz'.format(self.THz2Pi, width=self.decimals)
             string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+12)
-            data = '{0:.{width}f} cm-1'.format(self.cm1, width=self.decimals)
+            data   = '{0:.{width}f} cm-1'.format(self.cm1, width=self.decimals)
             string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+11)
-            data = '{0:.{width}f} meV'.format(self.meV, width=self.decimals)
+            data   = '{0:.{width}f} meV'.format(self.meV, width=self.decimals)
             string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+9)
         if(self.intensity != None and (printmode == "all" or printmode == "intensity")):
             if(printmode == "all"):
                 string += "\n"
-                data = '{0:.{width}f} x2'.format(self.intensity[0], width=self.decimals)
+                data   = '{0:.{width}f} x2'.format(self.intensity[0], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+13)
-                data = '{0:.{width}f} y2'.format(self.intensity[1], width=self.decimals)
+                data   = '{0:.{width}f} y2'.format(self.intensity[1], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+9)
-                data = '{0:.{width}f} z2'.format(self.intensity[2], width=self.decimals)
+                data   = '{0:.{width}f} z2'.format(self.intensity[2], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+13)
-                data = '{0:.{width}f} int'.format(self.intensity[3], width=self.decimals)
+                data   = '{0:.{width}f} int'.format(self.intensity[3], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+11)
             else:
-                data = '{0:.{width}f} x2'.format(self.intensity[0], width=self.decimals)
+                data   = '{0:.{width}f} x2'.format(self.intensity[0], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
-                data = '{0:.{width}f} y2'.format(self.intensity[1], width=self.decimals)
+                data   = '{0:.{width}f} y2'.format(self.intensity[1], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
-                data = '{0:.{width}f} z2'.format(self.intensity[2], width=self.decimals)
+                data   = '{0:.{width}f} z2'.format(self.intensity[2], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
-                data = '{0:.{width}f} int'.format(self.intensity[3], width=self.decimals)
+                data   = '{0:.{width}f} int'.format(self.intensity[3], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+7)
         return string
     def write(self, decimals_in = 6, spaces_in = 3, prefix = None, printmode = "all"):

--- a/castor/classes/dipols/subclass_frequency.py
+++ b/castor/classes/dipols/subclass_frequency.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 # 
-# subclass_intensity.py
+# subclass_frequency.py
 # 
 # Author: Bart Zijlstra
 # 

--- a/castor/classes/dipols/subclass_matrix.py
+++ b/castor/classes/dipols/subclass_matrix.py
@@ -23,19 +23,19 @@ class Matrix:
     """Defines the dipol matrix from a Hessian"""
     def __init__(self):
         self.decimals = 6
-        self.spaces = 3
-        self.dipols = []
+        self.spaces   = 3
+        self.dipols   = []
     def setup(self, dipol_diff, degrees_freedom, diff):
         #check if the amount of dipols match the degrees of freedom
         if(len(dipol_diff)!= 2*len(degrees_freedom)):
             print "Error, amounts of dipols and degrees of freedom do not match!"
             sys.exit()
 
-        atom = 0
+        atom      = 0
         direction = 0
-        dipcount = 0
+        dipcount  = 0
         for degree in degrees_freedom:
-            atom = int(degree[:-1])
+            atom      = int(degree[:-1])
             direction = degree[-1]
             #first dipol_diff is +diff, second dipol_diff is -diff
             mux = (dipol_diff[dipcount][0]-dipol_diff[dipcount+1][0])/(2*diff)
@@ -45,9 +45,9 @@ class Matrix:
             dipcount += 2
     def setIntensities(self,frequencies):
         for freq in frequencies:
-            sumx=0
-            sumy=0
-            sumz=0
+            sumx    = 0
+            sumy    = 0
+            sumz    = 0
             atcount = 0
             for atom in freq.atdiff:
                 atcount += 1
@@ -79,9 +79,9 @@ class Matrix:
             string = ""
             string += '{0:>{width}}'.format(dipol[0], width=self.spaces)
             string += '{0:>{width}}'.format(dipol[1], width=self.spaces)
-            xcor = '{0:.{width}f}'.format(dipol[2], width=self.decimals)
-            ycor = '{0:.{width}f}'.format(dipol[3], width=self.decimals)
-            zcor = '{0:.{width}f}'.format(dipol[4], width=self.decimals)
+            xcor   = '{0:.{width}f}'.format(dipol[2], width=self.decimals)
+            ycor   = '{0:.{width}f}'.format(dipol[3], width=self.decimals)
+            zcor   = '{0:.{width}f}'.format(dipol[4], width=self.decimals)
             string += '{0:>{width}}'.format(xcor, width=self.decimals+self.spaces+4)
             string += '{0:>{width}}'.format(ycor, width=self.decimals+self.spaces+4)
             string += '{0:>{width}}'.format(zcor, width=self.decimals+self.spaces+4)

--- a/castor/classes/hessian/subclass_frequency.py
+++ b/castor/classes/hessian/subclass_frequency.py
@@ -44,3 +44,60 @@ class Frequency:
         return string
     def write(self, decimals_in = 6, spaces_in = 3):
         print self.getString(decimals_in, spaces_in)
+
+class DipolFrequency:
+    """Defines a frequency"""
+    def __init__(self, Thz_in = 0, THz2Pi_in = 0, cm1_in = 0, meV_in = 0, imag_in = False):
+        self.THz = Thz_in
+        self.THz2Pi = THz2Pi_in
+        self.cm1 = cm1_in
+        self.meV = meV_in
+        self.imaginary = imag_in
+        self.atdiff = [] #filled by class_dipol.py during outcar read
+        self.intensity = None #set by subclass_matrix.py in setIntensities
+    def getString(self, decimals_in = 6, spaces_in = 3, prefix = None, printmode = "all"):
+        self.decimals = decimals_in
+        self.spaces = spaces_in
+        string = ""
+        if(prefix!=None):
+            string += '{0:>{width}}'.format(prefix, width=self.spaces)
+            string += " "
+        if(self.imaginary==False):
+            string += "f  ="
+        elif(self.imaginary==True):
+            string += "f/i="
+        if(printmode=="all" or printmode=="freq" or self.intensity == None):
+            data = '{0:.{width}f} THz'.format(self.THz, width=self.decimals)
+            string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
+            data = '{0:.{width}f} 2PiTHz'.format(self.THz2Pi, width=self.decimals)
+            string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+12)
+            data = '{0:.{width}f} cm-1'.format(self.cm1, width=self.decimals)
+            string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+11)
+            data = '{0:.{width}f} meV'.format(self.meV, width=self.decimals)
+            string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+9)
+        if(self.intensity != None and (printmode == "all" or printmode == "intensity")):
+            if(printmode == "all"):
+                string += "\n"
+                data = '{0:.{width}f} x2'.format(self.intensity[0], width=self.decimals)
+                string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+13)
+                data = '{0:.{width}f} y2'.format(self.intensity[1], width=self.decimals)
+                string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+9)
+                data = '{0:.{width}f} z2'.format(self.intensity[2], width=self.decimals)
+                string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+13)
+                data = '{0:.{width}f} int'.format(self.intensity[3], width=self.decimals)
+                string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+11)
+            else:
+                data = '{0:.{width}f} x2'.format(self.intensity[0], width=self.decimals)
+                string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
+                data = '{0:.{width}f} y2'.format(self.intensity[1], width=self.decimals)
+                string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
+                data = '{0:.{width}f} z2'.format(self.intensity[2], width=self.decimals)
+                string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
+                data = '{0:.{width}f} int'.format(self.intensity[3], width=self.decimals)
+                string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+7)
+        return string
+    def write(self, decimals_in = 6, spaces_in = 3, prefix = None, printmode = "all"):
+        print self.getString(decimals_in, spaces_in, prefix, printmode)
+    def writeDiff(self):
+        for diff in self.atdiff:
+            print diff

--- a/castor/classes/hessian/subclass_frequency.py
+++ b/castor/classes/hessian/subclass_frequency.py
@@ -35,9 +35,9 @@ class Frequency:
         self.atdiff    = atdiff_in
         self.imaginary = imag_in
     def getString(self, decimals_in = 6, spaces_in = 3, prefix = None, printmode = "all"):
-        self.decimals = decimals_in
-        self.spaces   = spaces_in
-        string        = ""
+        self.decimals  = decimals_in
+        self.spaces    = spaces_in
+        string         = ""
         if(prefix!=None):
             string += '{0:>{width}}'.format(prefix, width=self.spaces)
             string += " "

--- a/castor/classes/hessian/subclass_frequency.py
+++ b/castor/classes/hessian/subclass_frequency.py
@@ -19,46 +19,25 @@ import math
 
 class Frequency:
     """Defines a frequency"""
-    def __init__(self, eigenval_in = 0, imag_in = False):
-        self.THz = eigenval_in*15.633304592
-        self.THz2Pi = eigenval_in*98.2269497148
-        self.cm1 = eigenval_in*521.47091
-        self.meV = eigenval_in*64.6541499
-        self.imaginary = imag_in
-    def getString(self, decimals_in = 6, spaces_in = 3):
-        self.decimals = decimals_in
-        self.spaces = spaces_in
-        string = ""
-        if(self.imaginary==False):
-            string += "f  ="
-        elif(self.imaginary==True):
-            string += "f/i="
-        data = '{0:.{width}f} THz'.format(self.THz, width=self.decimals)
-        string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
-        data = '{0:.{width}f} 2PiTHz'.format(self.THz2Pi, width=self.decimals)
-        string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+12)
-        data = '{0:.{width}f} cm-1'.format(self.cm1, width=self.decimals)
-        string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+11)
-        data = '{0:.{width}f} meV'.format(self.meV, width=self.decimals)
-        string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+9)
-        return string
-    def write(self, decimals_in = 6, spaces_in = 3):
-        print self.getString(decimals_in, spaces_in)
-
-class DipolFrequency:
-    """Defines a frequency"""
     def __init__(self, Thz_in = 0, THz2Pi_in = 0, cm1_in = 0, meV_in = 0, imag_in = False):
-        self.THz = Thz_in
-        self.THz2Pi = THz2Pi_in
-        self.cm1 = cm1_in
-        self.meV = meV_in
+        self.THz       = Thz_in
+        self.THz2Pi    = THz2Pi_in
+        self.cm1       = cm1_in
+        self.meV       = meV_in
         self.imaginary = imag_in
-        self.atdiff = [] #filled by class_dipol.py during outcar read
-        self.intensity = None #set by subclass_matrix.py in setIntensities
+        self.atdiff    = dict() # Filled by class_dipol.py during outcar read
+        self.intensity = None   # Set by subclass_matrix.py in setIntensities
+    def setEigen(self, eigenval_in = 0, atdiff_in = dict(), imag_in = False):
+        self.THz       = eigenval_in*15.633304592
+        self.THz2Pi    = eigenval_in*98.2269497148
+        self.cm1       = eigenval_in*521.47091
+        self.meV       = eigenval_in*64.6541499
+        self.atdiff    = atdiff_in
+        self.imaginary = imag_in
     def getString(self, decimals_in = 6, spaces_in = 3, prefix = None, printmode = "all"):
         self.decimals = decimals_in
-        self.spaces = spaces_in
-        string = ""
+        self.spaces   = spaces_in
+        string        = ""
         if(prefix!=None):
             string += '{0:>{width}}'.format(prefix, width=self.spaces)
             string += " "
@@ -67,33 +46,33 @@ class DipolFrequency:
         elif(self.imaginary==True):
             string += "f/i="
         if(printmode=="all" or printmode=="freq" or self.intensity == None):
-            data = '{0:.{width}f} THz'.format(self.THz, width=self.decimals)
+            data   = '{0:.{width}f} THz'.format(self.THz, width=self.decimals)
             string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
-            data = '{0:.{width}f} 2PiTHz'.format(self.THz2Pi, width=self.decimals)
+            data   = '{0:.{width}f} 2PiTHz'.format(self.THz2Pi, width=self.decimals)
             string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+12)
-            data = '{0:.{width}f} cm-1'.format(self.cm1, width=self.decimals)
+            data   = '{0:.{width}f} cm-1'.format(self.cm1, width=self.decimals)
             string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+11)
-            data = '{0:.{width}f} meV'.format(self.meV, width=self.decimals)
+            data   = '{0:.{width}f} meV'.format(self.meV, width=self.decimals)
             string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+9)
         if(self.intensity != None and (printmode == "all" or printmode == "intensity")):
             if(printmode == "all"):
                 string += "\n"
-                data = '{0:.{width}f} x2'.format(self.intensity[0], width=self.decimals)
+                data   = '{0:.{width}f} x2'.format(self.intensity[0], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+13)
-                data = '{0:.{width}f} y2'.format(self.intensity[1], width=self.decimals)
+                data   = '{0:.{width}f} y2'.format(self.intensity[1], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+9)
-                data = '{0:.{width}f} z2'.format(self.intensity[2], width=self.decimals)
+                data   = '{0:.{width}f} z2'.format(self.intensity[2], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+13)
-                data = '{0:.{width}f} int'.format(self.intensity[3], width=self.decimals)
+                data   = '{0:.{width}f} int'.format(self.intensity[3], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+11)
             else:
-                data = '{0:.{width}f} x2'.format(self.intensity[0], width=self.decimals)
+                data   = '{0:.{width}f} x2'.format(self.intensity[0], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
-                data = '{0:.{width}f} y2'.format(self.intensity[1], width=self.decimals)
+                data   = '{0:.{width}f} y2'.format(self.intensity[1], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
-                data = '{0:.{width}f} z2'.format(self.intensity[2], width=self.decimals)
+                data   = '{0:.{width}f} z2'.format(self.intensity[2], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+6)
-                data = '{0:.{width}f} int'.format(self.intensity[3], width=self.decimals)
+                data   = '{0:.{width}f} int'.format(self.intensity[3], width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+7)
         return string
     def write(self, decimals_in = 6, spaces_in = 3, prefix = None, printmode = "all"):

--- a/castor/classes/hessian/subclass_matrix.py
+++ b/castor/classes/hessian/subclass_matrix.py
@@ -96,9 +96,9 @@ class Matrix:
 
         for degree,diffvec in zip(freedom_reduced,self.diag[1].tolist()):
             for atdiff, diff in zip(fulldiff,diffvec):
-                atom = int(degree[:-1])
+                atom      = int(degree[:-1])
                 direction = degree[-1]
-                mass = map_in[atom]
+                mass      = map_in[atom]
                 if(direction == "X"):
                     atdiff[atom][0] = diff/math.sqrt(mass)
                 elif(direction == "Y"):
@@ -163,17 +163,17 @@ class Dipols:
     """Defines the dipol matrix from a Hessian"""
     def __init__(self):
         self.decimals = 6
-        self.spaces = 3
-        self.dipols = []
+        self.spaces   = 3
+        self.dipols   = []
     def setup(self, dipol_diff, degrees_freedom, diff):
         #check if the amount of dipols match the degrees of freedom
         if(len(dipol_diff)!= 2*len(degrees_freedom)):
             print "Error, amounts of dipols and degrees of freedom do not match!"
             sys.exit()
 
-        atom = 0
+        atom      = 0
         direction = 0
-        dipcount = 0
+        dipcount  = 0
         for degree in degrees_freedom:
             atom = int(degree[:-1])
             direction = degree[-1]
@@ -185,9 +185,9 @@ class Dipols:
             dipcount += 2
     def setIntensities(self,frequencies):
         for freq in frequencies:
-            sumx=0
-            sumy=0
-            sumz=0
+            sumx = 0
+            sumy = 0
+            sumz = 0
             for dictionary in freq.atdiff:
                 atom = dictionary
                 diff = freq.atdiff[dictionary]
@@ -205,7 +205,7 @@ class Dipols:
                             sumx+=dip[2]* diff[2]
                             sumy+=dip[3]* diff[2]
                             sumz+=dip[4]* diff[2]
-            totaldipol = sumx**2 + sumy**2 + sumz**2
+            totaldipol     = sumx**2 + sumy**2 + sumz**2
             freq.intensity = [sumx**2,sumy**2,sumz**2,totaldipol]
 
     def printMatrix(self):
@@ -219,9 +219,9 @@ class Dipols:
             string = ""
             string += '{0:>{width}}'.format(dipol[0], width=self.spaces)
             string += '{0:>{width}}'.format(dipol[1], width=self.spaces)
-            xcor = '{0:.{width}f}'.format(dipol[2], width=self.decimals)
-            ycor = '{0:.{width}f}'.format(dipol[3], width=self.decimals)
-            zcor = '{0:.{width}f}'.format(dipol[4], width=self.decimals)
+            xcor   = '{0:.{width}f}'.format(dipol[2], width=self.decimals)
+            ycor   = '{0:.{width}f}'.format(dipol[3], width=self.decimals)
+            zcor   = '{0:.{width}f}'.format(dipol[4], width=self.decimals)
             string += '{0:>{width}}'.format(xcor, width=self.decimals+self.spaces+4)
             string += '{0:>{width}}'.format(ycor, width=self.decimals+self.spaces+4)
             string += '{0:>{width}}'.format(zcor, width=self.decimals+self.spaces+4)

--- a/castor/classes/hessian/subclass_matrix.py
+++ b/castor/classes/hessian/subclass_matrix.py
@@ -18,6 +18,7 @@ import numpy as np
 
 #MY CLASSES
 from subclass_frequency import Frequency
+from subclass_frequency import DipolFrequency
 
 class Matrix:
     """Defines the matrices of a Hessian"""
@@ -127,3 +128,71 @@ class Matrix:
                 name = str(atom)+axis
                 string += '{0:>{width}}'.format(name, width=self.decimals+self.spaces+3)
         print string
+
+class Dipols:
+    """Defines the dipol matrix from a Hessian"""
+    def __init__(self):
+        self.decimals = 6
+        self.spaces = 3
+        self.dipols = []
+    def setup(self, dipol_diff, degrees_freedom, diff):
+        #check if the amount of dipols match the degrees of freedom
+        if(len(dipol_diff)!= 2*len(degrees_freedom)):
+            print "Error, amounts of dipols and degrees of freedom do not match!"
+            sys.exit()
+
+        atom = 0
+        direction = 0
+        dipcount = 0
+        for degree in degrees_freedom:
+            atom = int(degree[:-1])
+            direction = degree[-1]
+            #first dipol_diff is +diff, second dipol_diff is -diff
+            mux = (dipol_diff[dipcount][0]-dipol_diff[dipcount+1][0])/(2*diff)
+            muy = (dipol_diff[dipcount][1]-dipol_diff[dipcount+1][1])/(2*diff)
+            muz = (dipol_diff[dipcount][2]-dipol_diff[dipcount+1][2])/(2*diff)
+            self.dipols.append([atom,direction,mux, muy, muz])
+            dipcount += 2
+    def setIntensities(self,frequencies):
+        for freq in frequencies:
+            sumx=0
+            sumy=0
+            sumz=0
+            atcount = 0
+            for atom in freq.atdiff:
+                atcount += 1
+                for dip in self.dipols:
+                    if(dip[0] == atcount):
+                        if(dip[1] == "X"):
+                            sumx+=dip[2]* atom[0]
+                            sumy+=dip[3]* atom[0]
+                            sumz+=dip[4]* atom[0]
+                        elif(dip[1] == "Y"):
+                            sumx+=dip[2]* atom[1]
+                            sumy+=dip[3]* atom[1]
+                            sumz+=dip[4]* atom[1]
+                        elif(dip[1] == "Z"):
+                            sumx+=dip[2]* atom[2]
+                            sumy+=dip[3]* atom[2]
+                            sumz+=dip[4]* atom[2]
+            totaldipol = sumx**2 + sumy**2 + sumz**2
+            freq.intensity = [sumx**2,sumy**2,sumz**2,totaldipol]
+
+    def printMatrix(self):
+        for dipol in self.dipols:
+            print dipol
+
+    def printMatrix(self, decimals_in = 6, spaces_in = 3):
+        self.decimals = decimals_in
+        self.spaces = spaces_in
+        for dipol in self.dipols:
+            string = ""
+            string += '{0:>{width}}'.format(dipol[0], width=self.spaces)
+            string += '{0:>{width}}'.format(dipol[1], width=self.spaces)
+            xcor = '{0:.{width}f}'.format(dipol[2], width=self.decimals)
+            ycor = '{0:.{width}f}'.format(dipol[3], width=self.decimals)
+            zcor = '{0:.{width}f}'.format(dipol[4], width=self.decimals)
+            string += '{0:>{width}}'.format(xcor, width=self.decimals+self.spaces+4)
+            string += '{0:>{width}}'.format(ycor, width=self.decimals+self.spaces+4)
+            string += '{0:>{width}}'.format(zcor, width=self.decimals+self.spaces+4)
+            print string

--- a/castor/classes/hessian/subclass_matrix.py
+++ b/castor/classes/hessian/subclass_matrix.py
@@ -18,22 +18,20 @@ import numpy as np
 
 #MY CLASSES
 from subclass_frequency import Frequency
-from subclass_frequency import DipolFrequency
 
 class Matrix:
     """Defines the matrices of a Hessian"""
-    def __init__(self, atoms_in = None, axes_in = None):
-        self.decimals = 6
-        self.spaces = 3
-        self.atoms = atoms_in
-        self.axes = axes_in
+    def __init__(self, freedom_in):
+        self.decimals    = 6
+        self.spaces      = 3
+        self.freedom     = freedom_in
         self.frequencies = []
-        self.skipset = set()
+        self.skipset     = set()
     def setup(self, nonsym_in = None, sym_in = None, mass_in = None, diag_in = None):
         self.nonsym = nonsym_in
-        self.sym = sym_in
-        self.mass = mass_in
-        self.diag = diag_in
+        self.sym    = sym_in
+        self.mass   = mass_in
+        self.diag   = diag_in
     def nonsym2sym(self):
         if(self.nonsym == None or len(self.nonsym) == 0 or len(self.nonsym[0]) == 0):
             print "Can not symmetrize matrix because not symmetrized matrix does not exist!"
@@ -55,34 +53,69 @@ class Matrix:
             sys.exit()
         else:
             self.mass = []
-            for row, atom_row in zip(self.sym, self.atoms):
-                mass_row = map_in[atom_row]
-                rowlist = []
-                if(atom_row in set_in):
-                    redefineAxes = True
+            for row, degree in zip(self.sym, self.freedom):
+                atom     = int(degree[:-1])
+                mass_row = map_in[atom]
+                rowlist  = []
+                if(atom in self.skipset):
+                    redefineAxes = True # Unused
                     continue
-                for column, atom_col in zip(row, self.atoms):
-                    mass_col = map_in[atom_col]
-                    if(atom_col in set_in):
-                        redefineAxes = True
+                for column, degree in zip(row, self.freedom):
+                    atom     = int(degree[:-1])
+                    mass_col = map_in[atom]
+                    if(atom in self.skipset):
+                        redefineAxes = True # Unused
                     else:
                         rowlist.append(column / math.sqrt(mass_row*mass_col))
                 self.mass.append(rowlist)
     def mass2diag(self):
+        # self.printMass()
         if(self.mass == None or len(self.mass) == 0 or len(self.mass[0]) == 0):
             print "Can not diagonalize mass matrix because it does not exist!"
             sys.exit()
         else:
             numpymat = np.matrix(self.mass)
             self.diag = np.linalg.eigh(numpymat)
-    def diag2freq(self):
-        for eigenval in self.diag[0]:
+    def diag2freq(self, map_in):
+        freedom_reduced     = []
+        set_reduced = set()
+        for degree in self.freedom:
+            atom = int(degree[:-1])
+            if(atom not in self.skipset):
+                set_reduced.add(atom)
+                freedom_reduced.append(degree)
+
+        # fulldiff will contain dict() for every DOF/FREQ
+        # dict() will contain atom number and [x.x, x.x, x.x] diff
+        fulldiff=[]
+        for degree in freedom_reduced:
+            dictionary = dict()
+            for atom in set_reduced:
+                dictionary[atom] = [0.0,0.0,0.0]
+            fulldiff.append(dictionary)
+
+        for degree,diffvec in zip(freedom_reduced,self.diag[1].tolist()):
+            for atdiff, diff in zip(fulldiff,diffvec):
+                atom = int(degree[:-1])
+                direction = degree[-1]
+                mass = map_in[atom]
+                if(direction == "X"):
+                    atdiff[atom][0] = diff/math.sqrt(mass)
+                elif(direction == "Y"):
+                    atdiff[atom][1] = diff/math.sqrt(mass)
+                elif(direction == "Z"):
+                    atdiff[atom][2] = diff/math.sqrt(mass)
+        # print "Filled fulldiff"
+        # print fulldiff
+
+        for eigenval,atdiff in zip(self.diag[0],fulldiff):
+            newfreq = Frequency()
+            eigenroot = math.sqrt(abs(eigenval))
             if(eigenval < 0):
-                eigenroot = math.sqrt(abs(eigenval))
-                self.frequencies.append(Frequency(eigenroot,False))
+                newfreq.setEigen(eigenroot,atdiff,False)
             elif(eigenval > 0):
-                eigenroot = math.sqrt(abs(eigenval))
-                self.frequencies.append(Frequency(eigenroot,True))
+                newfreq.setEigen(eigenroot,atdiff,True)
+            self.frequencies.append(newfreq)
     def printNonsym(self):
         self.printMatrix(self.nonsym)
     def printSym(self):
@@ -98,35 +131,32 @@ class Matrix:
             string += freq.getString()
             print string
     def printMatrix(self, matrix_in):
-        if(len(matrix_in) < len(self.atoms)):
+        if(len(matrix_in) < len(self.freedom)):
             self.printAxis_X(True)
-            atomlist = []
-            axeslist = []
-            for atom, axis in zip(self.atoms, self.axes):
+            freedomlist = []
+            for degree in self.freedom:
+                atom = int(degree[:-1])
                 if (atom in self.skipset):
                     pass
                 else:
-                    atomlist.append(atom)
-                    axeslist.append(axis)
+                    freedomlist.append(degree)
         else:
             self.printAxis_X(False)
-            atomlist = self.atoms
-            axeslist = self.axes
-        for row, atom_row, axes_row in zip(matrix_in, atomlist, axeslist):
-            name = str(atom_row)+axes_row
-            string = '{0:^{width}}'.format(name, width=self.spaces+2)
+            freedomlist = self.freedom
+        for row, degree in zip(matrix_in, freedomlist):
+            string = '{0:^{width}}'.format(degree, width=self.spaces+2)
             for column in row:
                 data = '{0:.{width}f}'.format(column, width=self.decimals)
                 string += '{0:>{width}}'.format(data, width=self.decimals+self.spaces+3)
             print string
     def printAxis_X(self,skip_bool = False):
         string = '{0:^{width}}'.format("", width=self.spaces+2)
-        for atom, axis in zip(self.atoms, self.axes):
+        for degree in self.freedom:
+            atom = int(degree[:-1])
             if (skip_bool == True and atom in self.skipset):
                 pass
             else:
-                name = str(atom)+axis
-                string += '{0:>{width}}'.format(name, width=self.decimals+self.spaces+3)
+                string += '{0:>{width}}'.format(degree, width=self.decimals+self.spaces+3)
         print string
 
 class Dipols:
@@ -158,23 +188,23 @@ class Dipols:
             sumx=0
             sumy=0
             sumz=0
-            atcount = 0
-            for atom in freq.atdiff:
-                atcount += 1
+            for dictionary in freq.atdiff:
+                atom = dictionary
+                diff = freq.atdiff[dictionary]
                 for dip in self.dipols:
-                    if(dip[0] == atcount):
+                    if(dip[0] == atom):
                         if(dip[1] == "X"):
-                            sumx+=dip[2]* atom[0]
-                            sumy+=dip[3]* atom[0]
-                            sumz+=dip[4]* atom[0]
+                            sumx+=dip[2]* diff[0]
+                            sumy+=dip[3]* diff[0]
+                            sumz+=dip[4]* diff[0]
                         elif(dip[1] == "Y"):
-                            sumx+=dip[2]* atom[1]
-                            sumy+=dip[3]* atom[1]
-                            sumz+=dip[4]* atom[1]
+                            sumx+=dip[2]* diff[1]
+                            sumy+=dip[3]* diff[1]
+                            sumz+=dip[4]* diff[1]
                         elif(dip[1] == "Z"):
-                            sumx+=dip[2]* atom[2]
-                            sumy+=dip[3]* atom[2]
-                            sumz+=dip[4]* atom[2]
+                            sumx+=dip[2]* diff[2]
+                            sumy+=dip[3]* diff[2]
+                            sumz+=dip[4]* diff[2]
             totaldipol = sumx**2 + sumy**2 + sumz**2
             freq.intensity = [sumx**2,sumy**2,sumz**2,totaldipol]
 

--- a/castor/getfreq.py
+++ b/castor/getfreq.py
@@ -23,10 +23,10 @@ class Arguments:
     def __init__(self):
         self.outcar    = "OUTCAR"
         self.numbers   = None
-        self.element   = "H"
+        self.element   = None
         self.mass      = 2.0
         self.printmode = "all"
-        self.skip      = False
+        self.skip      = None
     def setup(self, arg_in):
         readmode = None
         for i in range(1,len(arg_in)):
@@ -54,8 +54,9 @@ class Arguments:
                         sys.exit()
                 readmode = None
                 continue
-            if(sys.argv[i] == "-s" or sys.argv[i] == "--skip"):
-                self.skip = True
+            if(readmode=="skip"):
+                self.skip = arg_in[i]
+                readmode = None
                 continue
             if(sys.argv[i] == "-h" or sys.argv[i] == "--help"):
                 self.help()
@@ -72,6 +73,9 @@ class Arguments:
             elif(sys.argv[i] == "-m" or sys.argv[i] == "--mass"):
                 readmode = "mass"
                 continue
+            elif(sys.argv[i] == "-s" or sys.argv[i] == "--skip"):
+                readmode = "skip"
+                continue
             elif(sys.argv[i] == "-l" or sys.argv[i] == "--less"):
                 self.printmode = "less"
                 continue
@@ -85,24 +89,14 @@ class Arguments:
                 print "Unexpected argument: " + sys.argv[i]
                 self.help()
                 sys.exit()
-    def getOutcar(self):
-        return self.outcar
-    def getNumbers(self):
-        return self.numbers
-    def getElement(self):
-        return self.element
-    def getMass(self):
-        return self.mass
-    def getPrintmode(self):
-        return self.printmode
     def help(self):
         print "Use: getfreq.py <options>"
         print "Options:"
-        print "-o or --outcar <outcar name>  | Example: $getfreq.py -o out (Default = OUTCAR)"
-        print "-n or --numbers <numbers>     | Example: $getfreq.py -n 34,36,38-40 (Default = all)"
-        print "-e or --element <element>     | Example: $getfreq.py -e C (Default = H)"
-        print "-m or --mass <mass>           | Example: $getfreq.py -m 13.0 (Default = 2.0)"
-        print "-s or --skip                  | Removes matrix elements for -n. Example: $getfreq.py -s -n 38-40"
+        print "-o or --outcar <outcar name>  | OUTCAR name to read. Example: $getfreq.py -o out (Default = OUTCAR)"
+        print "-e or --element <element>     | Element type to change mass. Example: $getfreq.py -e H (Default = None)"
+        print "-n or --numbers <numbers>     | Atom numbers of type. Example: $getfreq.py -n 34,36,38-40 (Default = all)"
+        print "-m or --mass <mass>           | Mass to set for selected atoms. Example: $getfreq.py -m 13.0 (Default = 2.0)"
+        print "-s or --skip <numbers>        | Removes matrix elements for <numbers>. Example: $getfreq.py -s 38-40"
         print "-l or --less                  | Set printmode to 'less' (Default = all)"
         print ""
         print "-h or --help                  | displays this help message"
@@ -118,13 +112,13 @@ def main(arg_in):
     hessian.matrix.diag2freq(hessian.massmap)
     if(hessian.idipol > 0):
         hessian.getDipols()
-        hessian.writeDipols()
-    if(arguments.skip == False):
+        # hessian.writeDipols()
+    if(arguments.skip == None):
         hessian.mapMass(arguments.element, arguments.mass, arguments.numbers) # from numberlist, change all element masses to mass
         hessian.setSkip(None)
-    elif(arguments.skip == True):
+    elif(arguments.skip != None):
         hessian.mapMass(None, None, None)
-        hessian.setSkip(arguments.numbers) # from numberlist, change all matrix elements to zero
+        hessian.setSkip(arguments.skip) # from numberlist, change all matrix elements to zero
     if(hessian.changes == True):
         hessian.addmatrix()
         hessian.newmatrices[0].sym2mass(hessian.massmap,hessian.skipset)

--- a/castor/getfreq.py
+++ b/castor/getfreq.py
@@ -21,12 +21,12 @@ from classes.class_hessian import Hessian
 class Arguments:
     """Defines a set of arguments"""
     def __init__(self):
-        self.outcar = "OUTCAR"
-        self.numbers = None
-        self.element = "H"
-        self.mass = 2.0
+        self.outcar    = "OUTCAR"
+        self.numbers   = None
+        self.element   = "H"
+        self.mass      = 2.0
         self.printmode = "all"
-        self.skip = False
+        self.skip      = False
     def setup(self, arg_in):
         readmode = None
         for i in range(1,len(arg_in)):

--- a/castor/getfreq.py
+++ b/castor/getfreq.py
@@ -113,21 +113,24 @@ def main(arg_in):
     arguments = Arguments()
     arguments.setup(arg_in)
     hessian = Hessian()
-    hessian.read(arguments.getOutcar())
+    hessian.read(arguments.outcar)
     hessian.matrix.mass2diag()
     hessian.matrix.diag2freq()
+    if(hessian.idipol > 0):
+        hessian.getDipols()
+        hessian.writeDipols()
     if(arguments.skip == False):
-        hessian.mapMass(arguments.getElement(), arguments.getMass(), arguments.getNumbers()) # from numberlist, change all element masses to mass
+        hessian.mapMass(arguments.element, arguments.mass, arguments.numbers) # from numberlist, change all element masses to mass
         hessian.setSkip(None)
     elif (arguments.skip == True):
         hessian.mapMass(None, None, None)
-        hessian.setSkip(arguments.getNumbers()) # from numberlist, change all matrix elements to zero
+        hessian.setSkip(arguments.numbers) # from numberlist, change all matrix elements to zero
     if(hessian.changes == True):
         hessian.addmatrix()
         hessian.newmatrices[0].sym2mass(hessian.massmap,hessian.skipset)
         hessian.newmatrices[0].mass2diag()
         hessian.newmatrices[0].diag2freq()
-    hessian.write(arguments.getPrintmode())
+    hessian.write(arguments.printmode)
 
 #EXECUTION
 main(sys.argv)

--- a/castor/getfreq.py
+++ b/castor/getfreq.py
@@ -115,21 +115,23 @@ def main(arg_in):
     hessian = Hessian()
     hessian.read(arguments.outcar)
     hessian.matrix.mass2diag()
-    hessian.matrix.diag2freq()
+    hessian.matrix.diag2freq(hessian.massmap)
     if(hessian.idipol > 0):
         hessian.getDipols()
         hessian.writeDipols()
     if(arguments.skip == False):
         hessian.mapMass(arguments.element, arguments.mass, arguments.numbers) # from numberlist, change all element masses to mass
         hessian.setSkip(None)
-    elif (arguments.skip == True):
+    elif(arguments.skip == True):
         hessian.mapMass(None, None, None)
         hessian.setSkip(arguments.numbers) # from numberlist, change all matrix elements to zero
     if(hessian.changes == True):
         hessian.addmatrix()
         hessian.newmatrices[0].sym2mass(hessian.massmap,hessian.skipset)
         hessian.newmatrices[0].mass2diag()
-        hessian.newmatrices[0].diag2freq()
+        hessian.newmatrices[0].diag2freq(hessian.massmap)
+        if(hessian.idipol > 0):
+            hessian.getNewIntens()
     hessian.write(arguments.printmode)
 
 #EXECUTION

--- a/castor/intense.py
+++ b/castor/intense.py
@@ -21,7 +21,7 @@ from classes.class_dipol import Dipols
 class Arguments:
     """Defines a set of arguments"""
     def __init__(self):
-        self.outcar = "OUTCAR"
+        self.outcar    = "OUTCAR"
         self.printmode = "intensity"
     def setup(self, arg_in):
         readmode = None


### PR DESCRIPTION
Square-root mass division is not done for the eigenvector output in Vasp 5 OUTCARS with NWRITE < 3. As such, the previous implementation of intensity.py was incomplete. This has been fixed. Furthermore, the intensity.py functionality was added to getfreq.py.